### PR TITLE
Include provisioning configuration similar to rpi images

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -23,6 +23,7 @@ define(NERVES_FW_DEVPATH, "/dev/mmcblk0")
 define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/mmcblk0p4") # Linux part number is 1-based
 define(NERVES_FW_APPLICATION_PART0_FSTYPE, "f2fs")
 define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
+define(NERVES_PROVISIONING, "${NERVES_SYSTEM}/images/fwup_include/provisioning.conf")
 
 # Default paths if not specified via the commandline
 define(ROOTFS, "${NERVES_SYSTEM}/images/rootfs.squashfs")

--- a/fwup_include/provisioning.conf
+++ b/fwup_include/provisioning.conf
@@ -1,0 +1,6 @@
+# Support setting device serial numbers when creating MicroSD cards.
+# Note that the '$' is escaped so that environment variable replacement
+# happens at "burn" time rather than at firmware creation time. No
+# serial numbers are stored in the .fw file. If left blank, the device
+# will default to a built-in ID.
+uboot_setenv(uboot-env, "nerves_serial_number", "\${NERVES_SERIAL_NUMBER}")

--- a/post-build.sh
+++ b/post-build.sh
@@ -2,10 +2,13 @@
 
 set -e
 
-# Create the revert script for manually switching back to the previously active
-# firmware.
+# Create the revert script for manually switching back to the previously
+# active firmware.
 mkdir -p $TARGET_DIR/usr/share/fwup
 $HOST_DIR/usr/bin/fwup -c -f $NERVES_DEFCONFIG_DIR/fwup-revert.conf -o $TARGET_DIR/usr/share/fwup/revert.fw
+
+# Copy the fwup includes to the images dir
+cp -rf $NERVES_DEFCONFIG_DIR/fwup_include $BINARIES_DIR
 
 # Since U-Boot's squashfs support is so slow (sadly), store the Linux
 # kernel in the FAT filesystem instead of /boot. Everything else can


### PR DESCRIPTION
Using the `nerves_system_srhub` without a local provisioning conf raises a very strange error when the `fwup.conf` tries to include the file. Defining the provisioning file and things work but it's very surprising if you don't have that in your project.

```
/home/eric/.nerves/artifacts/nerves_system_srhub-portable-0.27.1/images/fwup.conf:506: Cannot include the contents of an undefined variable
fwup: Error parsing configuration file '/home/eric/.nerves/artifacts/nerves_system_srhub-portable-0.27.1/images/fwup.conf'
** (Mix) Nerves encountered an error. %IO.Stream{device: :standard_io, raw: true, line_or_bytes: :line}
```