### PR TITLE
chore: add .claude/settings.json for Portkey repo tracking

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+    "env": {
+        "ANTHROPIC_CUSTOM_HEADERS": "x-portkey-metadata: {\"repo\": \"nerves_system_srhub\"}"
+    }
+}


### PR DESCRIPTION
## Summary

Adds `.claude/settings.json` with `ANTHROPIC_CUSTOM_HEADERS` configured to tag API requests with the repo name for Portkey metadata tracking.

This enables per-repo usage attribution in Portkey dashboards.

---
_Opened automatically via Claude Cowork automation._